### PR TITLE
Add Node 24 support (C++20, NAN 2.25)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,7 @@
   "targets": [{
     "target_name"    : "metrohash",
     "sources"        : [ "./src/metrohash_wrapper.cpp", "./src/metrohash128.cpp", "./src/metrohash128crc.cpp", "./src/metrohash64.cpp" ],
-    "cflags"         : [ "-std=c++11 -Wno-deprecated-declarations -Wno-unused-value -Wno-unused-function -Wno-unknown-pragmas -Wno-format -msse4.2" ],
+    "cflags"         : [ "<!(node -e \"console.log(parseInt(process.versions.node)>=24?'-std=c++20':'-std=c++17')\") -Wno-deprecated-declarations -Wno-unused-value -Wno-unused-function -Wno-unknown-pragmas -Wno-format -msse4.2" ],
     "include_dirs"   : [ "<!(node -e \"require('nan')\")" ],
     "defines"        : [ "__USE_XOPEN2K8" ],
     "conditions"   : [
@@ -10,7 +10,7 @@
         "xcode_settings" : {
           "MACOSX_DEPLOYMENT_TARGET" : "10.9",
           "OTHER_CFLAGS"             : [
-            "-std=c++17",
+            "<!(node -e \"console.log(parseInt(process.versions.node)>=24?'-std=c++20':'-std=c++17')\")",
             "-stdlib=libc++",
             "-Wno-unused-function",
             "-Wno-deprecated-declarations",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "metrohash",
-      "version": "2.8.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
-        "nan": "^2.22.0",
+        "nan": "^2.25.0",
         "node-gyp": "^10.3.1"
       },
       "devDependencies": {
@@ -1243,9 +1243,9 @@
       "license": "MIT"
     },
     "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
       "license": "MIT"
     },
     "node_modules/negotiator": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.22.0",
+    "nan": "^2.25.0",
     "node-gyp": "^10.3.1"
   },
   "devDependencies": {

--- a/src/metrohash_wrapper.cpp
+++ b/src/metrohash_wrapper.cpp
@@ -158,4 +158,4 @@ NAN_MODULE_INIT(InitAll) {
     Nan::Set(target, name128, fn128);
 }
 
-NODE_MODULE(metrohash, InitAll)
+NAN_MODULE_WORKER_ENABLED(metrohash, InitAll)


### PR DESCRIPTION
## Summary
- Dynamically select C++ standard (`-std=c++20` for Node 24+, `-std=c++17` for older) so the native addon compiles on both new and old Node versions
- Upgrade NAN from 2.22.0 to 2.25.0 for Node 24 V8 API compatibility
- Replace `NODE_MODULE` with `NAN_MODULE_WORKER_ENABLED` to fix `-Wcast-function-type-mismatch` warning