### PR TITLE
Support arm64 on linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,10 +2,22 @@
   "targets": [{
     "target_name"    : "metrohash",
     "sources"        : [ "./src/metrohash_wrapper.cpp", "./src/metrohash128.cpp", "./src/metrohash128crc.cpp", "./src/metrohash64.cpp" ],
-    "cflags"         : [ "<!(node -e \"console.log(parseInt(process.versions.node)>=24?'-std=c++20':'-std=c++17')\") -Wno-deprecated-declarations -Wno-unused-value -Wno-unused-function -Wno-unknown-pragmas -Wno-format -msse4.2" ],
+    "cflags"         : [
+      "<!(node -e \"console.log(parseInt(process.versions.node)>=24?'-std=c++20':'-std=c++17')\")",
+      "-Wno-deprecated-declarations",
+      "-Wno-unused-value",
+      "-Wno-unused-function",
+      "-Wno-unknown-pragmas",
+      "-Wno-format",
+      "-msse4.2"
+    ],
     "include_dirs"   : [ "<!(node -e \"require('nan')\")" ],
     "defines"        : [ "__USE_XOPEN2K8" ],
     "conditions"   : [
+      ["OS == 'linux' and target_arch == 'arm64'", {
+        "cflags!": ["-msse4.2"],
+        "cflags": ["-march=armv8-a+crc"]
+      }],
       ["OS == 'mac'", {
         "xcode_settings" : {
           "MACOSX_DEPLOYMENT_TARGET" : "10.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "metrohash",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",


### PR DESCRIPTION
This pull request updates the build configuration in `binding.gyp` to improve compatibility and maintainability, especially for Linux ARM64 architectures. The most important changes are:

**Build configuration improvements:**

* Reformatted the `cflags` array in `binding.gyp` to list each flag on a separate line, improving readability and maintainability.

**Platform-specific build support:**

* Added a condition for Linux ARM64 (`OS == 'linux' and target_arch == 'arm64'`) to remove the `-msse4.2` flag (which is x86-specific) and add the `-march=armv8-a+crc` flag for proper ARM64 support.